### PR TITLE
Refactor convert_user_string to do the same thing in less lines

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -28,10 +28,9 @@ LETTER_CONVERTER = {
 }
 
 def convert_user_string(input : String) : Int32
-	count = 0
-	input.each_char do |char|
-		count += LETTER_CONVERTER[char]
+	input_chars = input.chars
+	input_chars.sum do |char|
+		LETTER_CONVERTER[char]
 	end
-	count
 end
 

--- a/src/main.cr
+++ b/src/main.cr
@@ -28,8 +28,8 @@ LETTER_CONVERTER = {
 }
 
 def convert_user_string(input : String) : Int32
-	input_chars = input.chars
-	input_chars.sum do |char|
+	input_characters = input.chars
+	input_characters.sum do |char|
 		LETTER_CONVERTER[char]
 	end
 end


### PR DESCRIPTION
** Summary **
This PR refactors `convert_user_string` to achieve the same result without having to use a `count` variable.

** Main Changes **
- Refactor `convert_user_string` to convert it's input parameter into an array of characters first, then iterate over this array using `Enumerable#sum`