### PR TITLE
Simplify convert_user_string

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -28,8 +28,7 @@ LETTER_CONVERTER = {
 }
 
 def convert_user_string(input : String) : Int32
-	input_characters = input.chars
-	input_characters.sum do |char|
+	input.each_char.sum do |char|
 		LETTER_CONVERTER[char]
 	end
 end


### PR DESCRIPTION
Simplify `convert_user_string` in `main.cr` by passing the `Iterator` returned from `String#each_char` to `Enumerable#sum`. This removes the need for an intermediary character array.